### PR TITLE
Adding checkv skips to avoid overnight errors

### DIFF
--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -59,6 +59,10 @@ module "dns_mod" {
 }
 
 resource "aws_alb" "testalb" {
+  # A number of tests to ignore to stop errors in the overnight check
+  # checkov:skip=CKV_AWS_150 "Ensure that Load Balancer has deletion protection enabled - Not applicable in the test"
+  # checkov:skip=CKV_AWS_91: "Ensure the ELBv2 (Application/Network) has access logging enabled - not appropriate in the test"
+  # checkov:skip=CKV2_AWS_28: "Ensure public facing ALB are protected by WAF - not required in the test"
   name               = "alb-test"
   internal           = false
   load_balancer_type = "application"


### PR DESCRIPTION
To add some skips to stop the overnight errors on checkov