### PR TITLE
:dependabot: Add Go Dependencies and fix terraform path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: "terraform"
-    directory: "/terraform"
+    directory: "/"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/test"
     schedule:
       interval: "daily"

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: ministryofjustice/github-actions/code-formatter@7c689fe2de15e1692f5cceceb132919ab854081c # v14
+      - uses: ministryofjustice/github-actions/code-formatter@8712624bc5138cb320d9e5a2c5d87d9cb92f9900 # v18.2.2
         with:
             ignore-files: "README.md"
         env:


### PR DESCRIPTION
Go Dependencies and fix terraform path, also bumps code formatter to the latest version. 