### PR TITLE
Update Terraform-Docs to use signed-commits

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,11 +4,8 @@ on:
     branches: [ main ]
   merge_group:
     branches: [ main ]
-  
 
-permissions:
-  contents: read
-
+permissions: {}
 
 jobs:  
   docs:
@@ -27,4 +24,12 @@ jobs:
         working-dir: .
         output-file: README.md
         output-method: inject
-        git-push: "true"
+        git-push: "false"
+
+    - name: Fix Git permissions
+      run: sudo chown -R $(whoami) .git/
+
+    - name: Run Signed Commit Action
+      uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@ee0701cae8ac3179d7989aca0bfabe99262a8083 # v3.2.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the `terraform-doc` action to use the `signed-commit` workflow rather than the built-in `git-push` command which is unsigned as per ticket https://github.com/ministryofjustice/modernisation-platform/issues/9858