### PR TITLE
Migrate TSA from github-action to MP-github-actions

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -18,14 +18,14 @@ jobs:
       pull-requests: write
     name: Terraform Static Analysis
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
+    if: github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@0442287e70970e2e732fbfecf17fd362d2d21dee # v3.2.6
+        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@2d1bb8ef39861ede2999271b530cb9dd87f18004 # v3.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@0442287e70970e2e732fbfecf17fd362d2d21dee # v3.2.6
+        uses: ministryofjustice/modernisation-platform-github-actions/terraform-static-analysis@2d1bb8ef39861ede2999271b530cb9dd87f18004 # v3.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This PR updates the .github/workflows/terraform-static-analysis.yml workflow to use the migrated version now offered from https://github.com/ministryofjustice/modernisation-platform-github-actions/tree/main/terraform-static-analysis