### PR TITLE
Updates version of go to required level for terratest workflow to run.

### DIFF
--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.23
+          go-version: 1.24
           cache: false
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:


### PR DESCRIPTION
Terratest workflow fails on v 1.22.3

See https://github.com/ministryofjustice/modernisation-platform-terraform-dns-certificates/actions/runs/17543960042/job/49821012974